### PR TITLE
Update devcontainer configuration for GitHub Codespaces

### DIFF
--- a/launch.json
+++ b/launch.json
@@ -5,7 +5,7 @@
             "name": "Listen for XDebug",
             "type": "php",
             "request": "launch",
-            "port": 8000,
+            "port": 9000,
             "program": "${workspaceFolder}/index.php"
         }
     ]

--- a/tasks.json
+++ b/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "Run PHP Server",
             "type": "shell",
-            "command": "php -S localhost:8000",
+            "command": "php -S 0.0.0.0:8000",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -14,7 +14,7 @@
         {
             "label": "Watch and Reload Server",
             "type": "shell",
-            "command": "live-server --port=8000 --host=0.0.0.0 --watch=.",
+            "command": "live-server --port=8080 --host=0.0.0.0 --watch=.",
             "group": {
                 "kind": "build",
                 "isDefault": false


### PR DESCRIPTION
Update `launch.json` and `tasks.json` to match forwarded ports and bind to all network interfaces.

* **launch.json**
  - Change the `port` for "Listen for XDebug" from 8000 to 9000.
  - Update the `program` to `${workspaceFolder}/index.php`.

* **tasks.json**
  - Update the `command` for "Run PHP Server" task to `php -S 0.0.0.0:8000` to bind to all network interfaces.
  - Change the `command` for "Watch and Reload Server" task to `live-server --port=8080 --host=0.0.0.0 --watch=.` to match the forwarded port for Live Server.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andiekobbietks/afjcardiff/pull/3?shareId=a92b0a7c-a861-485a-9b0d-55722337da72).