### PR TITLE
Fix Apache2 installation in Dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli
+FROM php:8.2-apache
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Update the base image in `.devcontainer/Dockerfile` to `php:8.2-apache`.

* Change the base image from `php:8.2-cli` to `php:8.2-apache`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andiekobbietks/afjcardiff/pull/7?shareId=f5ce7fd8-7971-4d25-99cd-9fee030bbcc9).