### PR TITLE
Fix JSON syntax in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
             "name": "Andie Kobbie",
             "email": "andiekobbietks@outlook.com"
         }
-    },
+    ],
     "require": {
         "php": "^8.2",
         "ext-pdo_mysql": "*",


### PR DESCRIPTION
Fix the JSON syntax error in `composer.json`.

* Add a comma after the closing brace of the "authors" array to ensure valid JSON syntax.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andiekobbietks/afjcardiff/pull/8?shareId=6e00e2b2-2cfe-4a2a-b904-e75155418290).