### PR TITLE
Add phpMyAdmin to project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,6 +21,12 @@ RUN npm install -g live-server
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
 
+# Install phpMyAdmin
+RUN apt-get update && apt-get install -y phpmyadmin
+
+# Configure Apache to serve phpMyAdmin
+RUN ln -s /usr/share/phpmyadmin /var/www/html/phpmyadmin
+
 # Set working directory
 WORKDIR /workspace/afjcardiff
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,6 @@
         "ms-vscode.vscode-node-azure-pack",
         "ms-vscode-remote.remote-containers"
     ],
-    "forwardPorts": [8000, 3306, 8080],
+    "forwardPorts": [8000, 3306, 8080, 8081],
     "postStartCommand": "live-server --port=8080 --host=0.0.0.0"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,12 @@ RUN npm install -g live-server
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
 
+# Install phpMyAdmin
+RUN apt-get update && apt-get install -y phpmyadmin
+
+# Configure Apache to serve phpMyAdmin
+RUN ln -s /usr/share/phpmyadmin /var/www/html/phpmyadmin
+
 # Copy project files
 COPY . /workspace/afjcardiff/
 

--- a/README.md
+++ b/README.md
@@ -376,3 +376,21 @@ The `devcontainer.json` file can be customized to fit your specific development 
      ```
 
 By customizing the `devcontainer.json` file, you can tailor the development environment to your specific needs and ensure a consistent setup for all developers working on the project.
+
+## Accessing phpMyAdmin
+
+To access phpMyAdmin, follow these steps:
+
+1. **Start the Development Environment**
+   - Ensure your development environment is running as described in the "Setting Up the Development Environment" section.
+
+2. **Open phpMyAdmin**
+   - Open your web browser and navigate to `http://localhost:8081/phpmyadmin`.
+
+3. **Login to phpMyAdmin**
+   - Use your MySQL credentials to log in:
+     - **Username**: `root`
+     - **Password**: `yourpassword`
+
+4. **Manage Your Database**
+   - You can now use phpMyAdmin to manage your MySQL database.

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "AFJCardiff Development Environment",
     "image": "mcr.microsoft.com/devcontainers/php:8.2-apache-bullseye",
-    "forwardPorts": [8000, 3306, 8080],
+    "forwardPorts": [8000, 3306, 8080, 8081],
     "containerEnv": {
         "DB_HOST": "localhost",
         "DB_PORT": "3306",


### PR DESCRIPTION
Add phpMyAdmin to the project.

* **Dockerfile**: Add phpMyAdmin installation steps and configure Apache to serve phpMyAdmin.
* **.devcontainer/Dockerfile**: Add phpMyAdmin installation steps and configure Apache to serve phpMyAdmin.
* **.devcontainer/devcontainer.json**: Add port forwarding for phpMyAdmin.
* **devcontainer.json**: Add port forwarding for phpMyAdmin.
* **README.md**: Add instructions for accessing phpMyAdmin.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andiekobbietks/afjcardiff/pull/10?shareId=8f142fe0-08b0-4be9-9a94-023baa02dd63).