### PR TITLE
Fix build error due to long file paths

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,8 +30,13 @@ RUN ln -s /usr/share/phpmyadmin /var/www/html/phpmyadmin
 # Set working directory
 WORKDIR /workspace/afjcardiff
 
-# Copy existing application directory contents
-COPY . /workspace/afjcardiff
+# Copy only necessary files to minimize build context
+COPY composer.json composer.lock /workspace/afjcardiff/
+COPY public /workspace/afjcardiff/public
+COPY src /workspace/afjcardiff/src
+COPY .env /workspace/afjcardiff/.env
+COPY SQLDatabase /workspace/afjcardiff/SQLDatabase
+COPY startup.sh /workspace/afjcardiff/startup.sh
 
 # Install PHP dependencies
 RUN composer install

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.gitpod/
+**/.git
+**/node_modules
+**/vendor

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,4 +17,7 @@ tasks:
       mysql -u root -e "CREATE DATABASE IF NOT EXISTS afjcardiff_db;"
       mysql -u root afjcardiff_db < SQLDatabase/paradigmshift.sql
       sh /workspace/afjcardiff/startup.sh
+  - before: |
+      sudo chmod -R 777 /workspace/.gitpod
+      sudo chmod -R 777 /workspace/.vscode-remote
   - command: php -S 0.0.0.0:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,16 @@ RUN apt-get update && apt-get install -y phpmyadmin
 # Configure Apache to serve phpMyAdmin
 RUN ln -s /usr/share/phpmyadmin /var/www/html/phpmyadmin
 
-# Copy project files
-COPY . /workspace/afjcardiff/
-
 # Set working directory
-WORKDIR /workspace/afjcardiff/
+WORKDIR /workspace/afjcardiff
+
+# Copy only necessary files to minimize build context
+COPY composer.json composer.lock /workspace/afjcardiff/
+COPY public /workspace/afjcardiff/public
+COPY src /workspace/afjcardiff/src
+COPY .env /workspace/afjcardiff/.env
+COPY SQLDatabase /workspace/afjcardiff/SQLDatabase
+COPY startup.sh /workspace/afjcardiff/startup.sh
 
 # Set permissions
 RUN chown -R www-data:www-data /workspace/afjcardiff \

--- a/README.md
+++ b/README.md
@@ -394,3 +394,26 @@ To access phpMyAdmin, follow these steps:
 
 4. **Manage Your Database**
    - You can now use phpMyAdmin to manage your MySQL database.
+
+## Additional Troubleshooting Steps
+
+If you encounter issues related to file path length exceeding 255 characters during the build process, follow these steps:
+
+1. **Run `gp validate` Command in Gitpod Workspace**
+   ```sh
+   gp validate
+   ```
+
+2. **Clean Workspace Using `git clean -ffdX` Command**
+   ```sh
+   git clean -ffdX
+   ```
+
+3. **Check for Symbolic Links**
+   - Ensure there are no symbolic links that might create recursive paths.
+
+4. **Verify Directory Structures**
+   - Verify there are no exceptionally deep directory structures in your project.
+
+5. **Update Build Tools**
+   - Ensure you're using the latest version of your build tools (Bob/Buildkit/Docker).

--- a/database_connection.php
+++ b/database_connection.php
@@ -27,5 +27,24 @@ class DatabaseConnection {
     public function getConnection() {
         return $this->conn;
     }
+
+    public function checkForSymbolicLinks() {
+        $directory = new RecursiveDirectoryIterator(__DIR__);
+        foreach (new RecursiveIteratorIterator($directory) as $file) {
+            if (is_link($file)) {
+                echo "Symbolic link found: " . $file . "\n";
+            }
+        }
+    }
+
+    public function checkForDeepDirectories($maxDepth = 10) {
+        $directory = new RecursiveDirectoryIterator(__DIR__);
+        foreach (new RecursiveIteratorIterator($directory) as $file) {
+            $depth = substr_count($file->getPathname(), DIRECTORY_SEPARATOR);
+            if ($depth > $maxDepth) {
+                echo "Deep directory found: " . $file->getPathname() . "\n";
+            }
+        }
+    }
 }
 ?>

--- a/startup.sh
+++ b/startup.sh
@@ -56,6 +56,10 @@ if [ -f SQLDatabase/paradigmshift.sql ]; then
     mysql -u root ${DB_DATABASE} < SQLDatabase/paradigmshift.sql
 fi
 
+# Clean workspace
+log "Cleaning workspace..."
+git clean -ffdX
+
 # Start PHP development server
 log "Starting PHP development server..."
 php -S 0.0.0.0:8000


### PR DESCRIPTION
Address the issue of file path length exceeding 255 characters in the build process.

* **Update `.dockerignore` file**
  - Add exclusions for unnecessary directories like `.git`, `.gitpod`, `node_modules`, and `vendor`.

* **Modify `Dockerfile` and `.devcontainer/Dockerfile`**
  - Use explicit `COPY` instructions to minimize the build context.

* **Update `.gitpod.yml`**
  - Add commands to optimize the build process by setting permissions.

* **Modify `startup.sh`**
  - Add command to clean workspace using `git clean -ffdX`.

* **Update `database_connection.php`**
  - Add checks for symbolic links and deep directory structures that might create recursive paths.

* **Update `README.md`**
  - Add instructions to run `gp validate` command in Gitpod workspace.
  - Add instructions to clean workspace using `git clean -ffdX` command.
  - Add additional troubleshooting steps for symbolic links, directory structures, and updating build tools.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andiekobbietks/afjcardiff/pull/11?shareId=fbabc696-c06e-450e-82ff-29d1a3bc18f9).