### PR TITLE
Fix invalid properties in gitpod.yml

### DIFF
--- a/gitpod.yml
+++ b/gitpod.yml
@@ -1,0 +1,63 @@
+tasks:
+  - name: Initialize MySQL
+    init: |
+      docker-compose up -d
+      gp await-port 3306
+      mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS paradigmshift;"
+      mysql -u root -proot paradigmshift < SQLDatabase/paradigmshift.sql
+
+  - name: Start Apache
+    command: apachectl start
+
+  - name: Install Dependencies
+    init: |
+      composer install --no-dev
+      composer dump-autoload -o
+
+  - name: Environment Setup
+    init: |
+      cp .env.example .env
+      php artisan key:generate
+
+  - name: PHP Setup
+    init: |
+      composer install
+
+  - name: Apache & MySQL
+    init: |
+      mkdir -p /workspace/mysql
+      if [ ! -d "/workspace/mysql/mysql" ]; then
+        mysqld --initialize-insecure --datadir=/workspace/mysql
+      fi
+      mysqld --daemonize --datadir=/workspace/mysql
+    command: |
+      apache2ctl start
+      mysql -u root -e "CREATE DATABASE IF NOT EXISTS afjcardiff;"
+      mysql -u root -e "CREATE USER IF NOT EXISTS 'user'@'localhost' IDENTIFIED BY 'password';"
+      mysql -u root -e "GRANT ALL PRIVILEGES ON afjcardiff.* TO 'user'@'localhost';"
+      gp sync-done database
+
+  - name: Project Setup
+    init: |
+      composer install
+      gp sync-await database
+      mysql -u root afjcardiff < SQLDatabase/paradigmshift.sql
+
+  - init: composer install
+    command: php -S 0.0.0.0:8000 router.php
+
+ports:
+  - port: 8080
+    onOpen: open-preview
+    visibility: public
+    name: Web App
+  - port: 3306
+    onOpen: ignore
+    visibility: private
+    name: MySQL
+  - port: 8081
+    onOpen: open-browser
+    visibility: public
+    name: phpMyAdmin
+  - port: 8000
+    onOpen: open-preview


### PR DESCRIPTION
Update `gitpod.yml` to remove invalid properties and ensure it adheres to the correct schema.

* **Remove invalid properties**
  - Remove the `vscode` section with `extensions` and `onOpen` properties.
  - Remove multiple `init` and `command` properties under the `tasks` section.

* **Update tasks section**
  - Add a single `init` and `command` property for each task.
  - Include tasks for initializing MySQL, starting Apache, installing dependencies, environment setup, PHP setup, Apache & MySQL setup, and project setup.

* **Update ports section**
  - Define ports for Web App, MySQL, phpMyAdmin, and a preview port.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andiekobbietks/afjcardiff/pull/18?shareId=e821f919-4e60-4622-9148-6c58fe07102e).